### PR TITLE
Could com.xyh:ajp-bug:1.0-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/tomcat/ajp-bug/pom.xml
+++ b/tomcat/ajp-bug/pom.xml
@@ -40,4 +40,17 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>  
+            <artifactId>tomcat-coyote</artifactId>  
+            <version>7.0.39</version>  
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Hi, I am a user of project **_com.xyh:ajp-bug:1.0-SNAPSHOT_**. I found that its pom file introduced **_9_** dependencies. However, among them, **_2_** libraries (**_22%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_com.xyh:ajp-bug:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards